### PR TITLE
32 sub workflow for gene annotation

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -193,6 +193,7 @@ process {
         ]
         errorStrategy = 'ignore'
     }
+    
 
     withName: RMLSTPARSE {
         publishDir = [
@@ -206,6 +207,32 @@ process {
             mode: params.publish_dir_mode,
             pattern: '*_allele.csv'
             ]
+        ]
+    }
+    withName: PROKKA {
+        publishDir = [
+            path: { "${params.outdir}/PROKKA" },
+            mode: params.publish_dir_mode,
+            pattern: '*'
+        ]
+        ext.args = "--force"
+        
+    }
+
+    withName: BAKTA_BAKTADBDOWNLOAD {
+        publishDir = [
+            path: { "${params.outdir}/bakta_db" },
+            mode: params.publish_dir_mode,
+            pattern: '*'
+        ]
+        ext.args = '--type light'
+    }
+
+    withName: BAKTA_BAKTA {
+        publishDir = [
+            path: { "${params.outdir}/bakta" },
+            mode: params.publish_dir_mode,
+            pattern: '*'
         ]
     }
 

--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,16 @@
     "https://github.com/nf-core/modules.git": {
       "modules": {
         "nf-core": {
+          "bakta/bakta": {
+            "branch": "master",
+            "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
+            "installed_by": ["modules"]
+          },
+          "bakta/baktadbdownload": {
+            "branch": "master",
+            "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
+            "installed_by": ["modules"]
+          },
           "bedtools/bamtobed": {
             "branch": "master",
             "git_sha": "1d48427957205cb6acf1ffe330bd35b6bb8baa90",
@@ -228,6 +238,11 @@
           "porechop/abi": {
             "branch": "master",
             "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+            "installed_by": ["modules"]
+          },
+          "prokka": {
+            "branch": "master",
+            "git_sha": "8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a",
             "installed_by": ["modules"]
           },
           "pycoqc": {

--- a/modules/nf-core/bakta/bakta/environment.yml
+++ b/modules/nf-core/bakta/bakta/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bakta=1.8.2

--- a/modules/nf-core/bakta/bakta/main.nf
+++ b/modules/nf-core/bakta/bakta/main.nf
@@ -1,0 +1,72 @@
+process BAKTA_BAKTA {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bakta:1.8.2--pyhdfd78af_0' :
+        'biocontainers/bakta:1.8.2--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    path db
+    path proteins
+    path prodigal_tf
+
+    output:
+    tuple val(meta), path("${prefix}.embl")             , emit: embl
+    tuple val(meta), path("${prefix}.faa")              , emit: faa
+    tuple val(meta), path("${prefix}.ffn")              , emit: ffn
+    tuple val(meta), path("${prefix}.fna")              , emit: fna
+    tuple val(meta), path("${prefix}.gbff")             , emit: gbff
+    tuple val(meta), path("${prefix}.gff3")             , emit: gff
+    tuple val(meta), path("${prefix}.hypotheticals.tsv"), emit: hypotheticals_tsv
+    tuple val(meta), path("${prefix}.hypotheticals.faa"), emit: hypotheticals_faa
+    tuple val(meta), path("${prefix}.tsv")              , emit: tsv
+    tuple val(meta), path("${prefix}.txt")              , emit: txt
+    path "versions.yml"                                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
+    def prodigal_tf = prodigal_tf ? "--prodigal-tf ${prodigal_tf[0]}" : ""
+    """
+    bakta \\
+        $fasta \\
+        $args \\
+        --threads $task.cpus \\
+        --prefix $prefix \\
+        $proteins_opt \\
+        $prodigal_tf \\
+        --db $db
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bakta: \$(echo \$(bakta --version) 2>&1 | cut -f '2' -d ' ')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.embl
+    touch ${prefix}.faa
+    touch ${prefix}.ffn
+    touch ${prefix}.fna
+    touch ${prefix}.gbff
+    touch ${prefix}.gff3
+    touch ${prefix}.hypotheticals.tsv
+    touch ${prefix}.hypotheticals.faa
+    touch ${prefix}.tsv
+    touch ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bakta: \$(echo \$(bakta --version) 2>&1 | cut -f '2' -d ' ')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bakta/bakta/meta.yml
+++ b/modules/nf-core/bakta/bakta/meta.yml
@@ -1,0 +1,92 @@
+name: bakta_bakta
+description: Annotation of bacterial genomes (isolates, MAGs) and plasmids
+keywords:
+  - annotation
+  - fasta
+  - bacteria
+tools:
+  - bakta:
+      description: Rapid & standardized annotation of bacterial genomes, MAGs & plasmids.
+      homepage: https://github.com/oschwengers/bakta
+      documentation: https://github.com/oschwengers/bakta
+      tool_dev_url: https://github.com/oschwengers/bakta
+      doi: "10.1099/mgen.0.000685"
+      licence: ["GPL v3"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: |
+        FASTA file to be annotated. Has to contain at least a non-empty string dummy value.
+  - db:
+      type: file
+      description: |
+        Path to the Bakta database. Must have amrfinderplus database directory already installed within it (in a directory called 'amrfinderplus-db/').
+  - proteins:
+      type: file
+      description: FASTA/GenBank file of trusted proteins to first annotate from (optional)
+  - prodigal_tf:
+      type: file
+      description: Training file to use for Prodigal (optional)
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - txt:
+      type: file
+      description: genome statistics and annotation summary
+      pattern: "*.txt"
+  - tsv:
+      type: file
+      description: annotations as simple human readble tab separated values
+      pattern: "*.tsv"
+  - gff:
+      type: file
+      description: annotations & sequences in GFF3 format
+      pattern: "*.gff3"
+  - gbff:
+      type: file
+      description: annotations & sequences in (multi) GenBank format
+      pattern: "*.gbff"
+  - embl:
+      type: file
+      description: annotations & sequences in (multi) EMBL format
+      pattern: "*.embl"
+  - fna:
+      type: file
+      description: replicon/contig DNA sequences as FASTA
+      pattern: "*.fna"
+  - faa:
+      type: file
+      description: CDS/sORF amino acid sequences as FASTA
+      pattern: "*.faa"
+  - ffn:
+      type: file
+      description: feature nucleotide sequences as FASTA
+      pattern: "*.ffn"
+  - hypotheticals_tsv:
+      type: file
+      description: additional information on hypothetical protein CDS as simple human readble tab separated values
+      pattern: "*.hypotheticals.tsv"
+  - hypotheticals_faa:
+      type: file
+      description: hypothetical protein CDS amino acid sequences as FASTA
+      pattern: "*.hypotheticals.faa"
+authors:
+  - "@rpetit3"
+  - "@oschwengers"
+  - "@jfy133"
+maintainers:
+  - "@rpetit3"
+  - "@oschwengers"
+  - "@jfy133"

--- a/modules/nf-core/bakta/baktadbdownload/environment.yml
+++ b/modules/nf-core/bakta/baktadbdownload/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bakta=1.8.2

--- a/modules/nf-core/bakta/baktadbdownload/main.nf
+++ b/modules/nf-core/bakta/baktadbdownload/main.nf
@@ -1,0 +1,43 @@
+process BAKTA_BAKTADBDOWNLOAD {
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bakta:1.8.2--pyhdfd78af_0' :
+        'biocontainers/bakta:1.8.2--pyhdfd78af_0' }"
+
+    output:
+    path "db*"              , emit: db
+    path "versions.yml"     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    bakta_db \\
+        download \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bakta: \$(echo \$(bakta_db --version) 2>&1 | cut -f '2' -d ' ')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    """
+    echo "bakta_db \\
+        download \\
+        $args"
+
+    mkdir db
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bakta: \$(echo \$(bakta_db --version) 2>&1 | cut -f '2' -d ' ')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bakta/baktadbdownload/meta.yml
+++ b/modules/nf-core/bakta/baktadbdownload/meta.yml
@@ -1,0 +1,32 @@
+name: "bakta_baktadbdownload"
+description: Downloads BAKTA database from Zenodo
+keywords:
+  - bakta
+  - annotation
+  - fasta
+  - bacteria
+  - database
+  - download
+tools:
+  - bakta:
+      description: Rapid & standardized annotation of bacterial genomes, MAGs & plasmids
+      homepage: https://github.com/oschwengers/bakta
+      documentation: https://github.com/oschwengers/bakta
+      tool_dev_url: https://github.com/oschwengers/bakta
+      doi: "10.1099/mgen.0.000685"
+      licence: ["GPL v3"]
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - db:
+      type: directory
+      description: BAKTA database directory
+      pattern: "db*/"
+authors:
+  - "@jfy133"
+  - "@jasmezz"
+maintainers:
+  - "@jfy133"
+  - "@jasmezz"

--- a/modules/nf-core/prokka/environment.yml
+++ b/modules/nf-core/prokka/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::prokka=1.14.6

--- a/modules/nf-core/prokka/main.nf
+++ b/modules/nf-core/prokka/main.nf
@@ -4,7 +4,7 @@ process PROKKA {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/prokka%3A1.14.6--pl5321hdfd78af_4' :
+        'https://depot.galaxyproject.org/singularity/prokka:1.14.6--pl5321hdfd78af_4' :
         'biocontainers/prokka:1.14.6--pl5321hdfd78af_4' }"
 
     input:

--- a/modules/nf-core/prokka/main.nf
+++ b/modules/nf-core/prokka/main.nf
@@ -1,0 +1,52 @@
+process PROKKA {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/prokka%3A1.14.6--pl5321hdfd78af_4' :
+        'biocontainers/prokka:1.14.6--pl5321hdfd78af_4' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    path proteins
+    path prodigal_tf
+
+    output:
+    tuple val(meta), path("${prefix}/*.gff"), emit: gff
+    tuple val(meta), path("${prefix}/*.gbk"), emit: gbk
+    tuple val(meta), path("${prefix}/*.fna"), emit: fna
+    tuple val(meta), path("${prefix}/*.faa"), emit: faa
+    tuple val(meta), path("${prefix}/*.ffn"), emit: ffn
+    tuple val(meta), path("${prefix}/*.sqn"), emit: sqn
+    tuple val(meta), path("${prefix}/*.fsa"), emit: fsa
+    tuple val(meta), path("${prefix}/*.tbl"), emit: tbl
+    tuple val(meta), path("${prefix}/*.err"), emit: err
+    tuple val(meta), path("${prefix}/*.log"), emit: log
+    tuple val(meta), path("${prefix}/*.txt"), emit: txt
+    tuple val(meta), path("${prefix}/*.tsv"), emit: tsv
+    path "versions.yml" , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
+    def prodigal_tf = prodigal_tf ? "--prodigaltf ${prodigal_tf[0]}" : ""
+    """
+    prokka \\
+        $args \\
+        --cpus $task.cpus \\
+        --prefix $prefix \\
+        $proteins_opt \\
+        $prodigal_tf \\
+        $fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        prokka: \$(echo \$(prokka --version 2>&1) | sed 's/^.*prokka //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/prokka/meta.yml
+++ b/modules/nf-core/prokka/meta.yml
@@ -1,0 +1,90 @@
+name: prokka
+description: Whole genome annotation of small genomes (bacterial, archeal, viral)
+keywords:
+  - annotation
+  - fasta
+  - prokka
+tools:
+  - prokka:
+      description: Rapid annotation of prokaryotic genomes
+      homepage: https://github.com/tseemann/prokka
+      doi: "10.1093/bioinformatics/btu153"
+      licence: ["GPL v2"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: |
+        FASTA file to be annotated. Has to contain at least a non-empty string dummy value.
+  - proteins:
+      type: file
+      description: FASTA file of trusted proteins to first annotate from (optional)
+  - prodigal_tf:
+      type: file
+      description: Training file to use for Prodigal (optional)
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - gff:
+      type: file
+      description: annotation in GFF3 format, containing both sequences and annotations
+      pattern: "*.{gff}"
+  - gbk:
+      type: file
+      description: annotation in GenBank format, containing both sequences and annotations
+      pattern: "*.{gbk}"
+  - fna:
+      type: file
+      description: nucleotide FASTA file of the input contig sequences
+      pattern: "*.{fna}"
+  - faa:
+      type: file
+      description: protein FASTA file of the translated CDS sequences
+      pattern: "*.{faa}"
+  - ffn:
+      type: file
+      description: nucleotide FASTA file of all the prediction transcripts (CDS, rRNA, tRNA, tmRNA, misc_RNA)
+      pattern: "*.{ffn}"
+  - sqn:
+      type: file
+      description: an ASN1 format "Sequin" file for submission to Genbank
+      pattern: "*.{sqn}"
+  - fsa:
+      type: file
+      description: nucleotide FASTA file of the input contig sequences, used by "tbl2asn" to create the .sqn file
+      pattern: "*.{fsa}"
+  - tbl:
+      type: file
+      description: feature Table file, used by "tbl2asn" to create the .sqn file
+      pattern: "*.{tbl}"
+  - err:
+      type: file
+      description: unacceptable annotations - the NCBI discrepancy report.
+      pattern: "*.{err}"
+  - log:
+      type: file
+      description: contains all the output that Prokka produced during its run
+      pattern: "*.{log}"
+  - txt:
+      type: file
+      description: statistics relating to the annotated features found
+      pattern: "*.{txt}"
+  - tsv:
+      type: file
+      description: tab-separated file of all features (locus_tag,ftype,len_bp,gene,EC_number,COG,product)
+      pattern: "*.{tsv}"
+authors:
+  - "@rpetit3"
+maintainers:
+  - "@rpetit3"

--- a/nextflow.config
+++ b/nextflow.config
@@ -181,14 +181,17 @@ params {
 
     /* Annotation options */
     assembled_genome           = "/mnt/cidgoh-object-storage/hackathon/seqqc/genome_asm/GCA_010673125.1/GCA_010673125.1.fa" // ANNOTATION: path to test assembled genome file
-    
+
     // gene annotation options
     skip_gene_annotation       = false
     skip_prokka                = false
     skip_bakta                 = false
     skip_bakta_download        = false
     bakta_db                   = "/mnt/cidgoh-object-storage/database/bakta/db/"
-    
+    prodigal_training_file     = null
+    annotation_protein_file    = null
+
+
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -186,7 +186,6 @@ params {
     skip_gene_annotation       = false
     skip_prokka                = false
     skip_bakta                 = false
-    skip_bakta_download        = false
     bakta_db                   = "/mnt/cidgoh-object-storage/database/bakta/db/"
     prodigal_training_file     = null
     annotation_protein_file    = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -180,8 +180,15 @@ params {
     max_time                   = '240.h'
 
     /* Annotation options */
-    skip_gene_annotation       = false
     assembled_genome           = "/mnt/cidgoh-object-storage/hackathon/seqqc/genome_asm/GCA_010673125.1/GCA_010673125.1.fa" // ANNOTATION: path to test assembled genome file
+    
+    // gene annotation options
+    skip_gene_annotation       = false
+    skip_prokka                = false
+    skip_bakta                 = false
+    skip_bakta_download        = false
+    bakta_db                   = "/mnt/cidgoh-object-storage/database/bakta/db/"
+    
 
 }
 

--- a/subworkflows/local/gene_annotation.nf
+++ b/subworkflows/local/gene_annotation.nf
@@ -15,6 +15,10 @@ workflow GENE_ANNOTATION{
         // Initializing empty channels for the output files
         prokka_gff = Channel.empty()
         bakta_gff = Channel.empty()
+        prokka_fna = Channel.empty()
+        bakta_fna = Channel.empty()
+        prokka_faa = Channel.empty()
+        bakta_faa = Channel.empty()
         ch_versions = Channel.empty()
 
         // Checking if the prodigal training file is provided

--- a/subworkflows/local/gene_annotation.nf
+++ b/subworkflows/local/gene_annotation.nf
@@ -1,20 +1,67 @@
 // INCLUDING MODULES
+// Importing the necessary modules for the workflow
 include { BAKTA_BAKTA } from '../../modules/nf-core/bakta/bakta/main' 
 include { BAKTA_BAKTADBDOWNLOAD } from '../../modules/nf-core/bakta/baktadbdownload/main'
 include { PROKKA } from '../../modules/nf-core/prokka/main'                                                                          
-//workflow
 
-
+// Defining the workflow
 workflow GENE_ANNOTATION{
+    // Defining the input channel
     take: 
         ch_genome
 
+    // Defining the main process
     main:
-        PROKKA(ch_genome, [], [])
-        gff = PROKKA.out.gff
-        //ch_versions   = ch_versions.mix(PROKKA.out.versions)
+        // Initializing empty channels for the output files
+        prokka_gff = Channel.empty()
+        bakta_gff = Channel.empty()
+        ch_versions = Channel.empty()
 
+        // Checking if the prodigal training file is provided
+        if (!params.prodigal_training_file){
+            prodigal = []
+        }
+        else{
+            prodigals = file(params.prodigal_training_file, checkIfExists: true)
+        }
+
+        // Checking if the annotation protein file is provided
+        if (!params.annotation_protein_file){
+            proteins = []
+        }
+        else{
+            proteins = file(params.annotation_protein_file, checkIfExists: true)
+        }
+
+        // Running PROKKA if skip_prokka is not set to true
+        if (!params.skip_prokka){
+            PROKKA(ch_genome, proteins, prodigal)
+            prokka_gff = PROKKA.out.gff
+            ch_versions   = ch_versions.mix(PROKKA.out.versions)
+        }
+
+        // Running BAKTA if skip_bakta is not set to true
+
+        if(!params.skip_bakta){
+            // Checking if BAKTA download is skipped
+            if (!params.skip_bakta_download){
+                BAKTA_BAKTADBDOWNLOAD()
+                bakta_db = BAKTA_BAKTADBDOWNLOAD.out.db
+                ch_versions = ch_versions.mix(BAKTA_BAKTADBDOWNLOAD.out.versions)
+            }
+            else{
+                bakta_db = Channel.from(params.bakta_db)
+                
+            }
+            
+            BAKTA_BAKTA(ch_genome, bakta_db, proteins, prodigal)
+            bakta_gff = BAKTA_BAKTA.out.gff
+            ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions)
+        }
+        
+    // Defining the output channels
     emit:
-        gff
-        //ch_versions
-    }
+        bakta_gff
+        prokka_gff
+        ch_versions
+}

--- a/subworkflows/local/gene_annotation.nf
+++ b/subworkflows/local/gene_annotation.nf
@@ -46,7 +46,7 @@ workflow GENE_ANNOTATION{
 
         if(!params.skip_bakta){
             // Checking if BAKTA download is skipped
-            if (!params.skip_bakta_download){
+            if (!params.bakta_db){
                 BAKTA_BAKTADBDOWNLOAD()
                 bakta_db = BAKTA_BAKTADBDOWNLOAD.out.db
                 ch_versions = ch_versions.mix(BAKTA_BAKTADBDOWNLOAD.out.versions)

--- a/subworkflows/local/gene_annotation.nf
+++ b/subworkflows/local/gene_annotation.nf
@@ -1,13 +1,13 @@
 // INCLUDING MODULES
 // Importing the necessary modules for the workflow
-include { BAKTA_BAKTA } from '../../modules/nf-core/bakta/bakta/main' 
+include { BAKTA_BAKTA } from '../../modules/nf-core/bakta/bakta/main'
 include { BAKTA_BAKTADBDOWNLOAD } from '../../modules/nf-core/bakta/baktadbdownload/main'
-include { PROKKA } from '../../modules/nf-core/prokka/main'                                                                          
+include { PROKKA } from '../../modules/nf-core/prokka/main'
 
 // Defining the workflow
 workflow GENE_ANNOTATION{
     // Defining the input channel
-    take: 
+    take:
         ch_genome
 
     // Defining the main process
@@ -37,6 +37,8 @@ workflow GENE_ANNOTATION{
         if (!params.skip_prokka){
             PROKKA(ch_genome, proteins, prodigal)
             prokka_gff = PROKKA.out.gff
+            prokka_fna = PROKKA.out.fna
+            prokka_faa = PROKKA.out.faa
             ch_versions   = ch_versions.mix(PROKKA.out.versions)
         }
 
@@ -51,17 +53,23 @@ workflow GENE_ANNOTATION{
             }
             else{
                 bakta_db = Channel.from(params.bakta_db)
-                
+
             }
-            
+
             BAKTA_BAKTA(ch_genome, bakta_db, proteins, prodigal)
             bakta_gff = BAKTA_BAKTA.out.gff
+            bakta_fna = BAKTA_BAKTA.out.fna
+            bakta_faa = BAKTA_BAKTA.out.faa
             ch_versions = ch_versions.mix(BAKTA_BAKTA.out.versions)
         }
-        
+
     // Defining the output channels
     emit:
         bakta_gff
+        bakta_fna
+        bakta_faa
         prokka_gff
+        prokka_fna
+        prokka_faa
         ch_versions
 }

--- a/subworkflows/local/gene_annotation.nf
+++ b/subworkflows/local/gene_annotation.nf
@@ -1,0 +1,20 @@
+// INCLUDING MODULES
+include { BAKTA_BAKTA } from '../../modules/nf-core/bakta/bakta/main' 
+include { BAKTA_BAKTADBDOWNLOAD } from '../../modules/nf-core/bakta/baktadbdownload/main'
+include { PROKKA } from '../../modules/nf-core/prokka/main'                                                                          
+//workflow
+
+
+workflow GENE_ANNOTATION{
+    take: 
+        ch_genome
+
+    main:
+        PROKKA(ch_genome, [], [])
+        gff = PROKKA.out.gff
+        //ch_versions   = ch_versions.mix(PROKKA.out.versions)
+
+    emit:
+        gff
+        //ch_versions
+    }


### PR DESCRIPTION
A sub-workflow that contains `prokka` & `bakta` modules from nf-core. The parameters exposed are added to the `nextflow.config`. The `modules.json` is updated for the new modules. 
Both the annotation tools output gff files when required to connect to downstream analyses. All other output files are available through the `outdir`
The sub-workflow allows running prokka or bakta or both on a provided genome. There is an option to skip downloading bakta database is already provided using the config file. 

This pull request closes #32 